### PR TITLE
fix: Trigger onDropOutside callback when target is dropped outside wi…

### DIFF
--- a/src/useDropOutside.js
+++ b/src/useDropOutside.js
@@ -2,7 +2,6 @@ import { resolveDragImage } from './utils/resolveDragImage'
 
 // TODO: Add classes for drag operations
 // TODO: Add callback for drag cancellation
-// TODO: Fix drop outside window boundaries
 const useDropOutside = (node, { areaSelector, dragImage, onDropOutside, onDropInside }) => {
 	const safeArea = document.querySelector(areaSelector)
 
@@ -35,7 +34,11 @@ const useDropOutside = (node, { areaSelector, dragImage, onDropOutside, onDropIn
 		document.removeEventListener('dragover', _onDragOver)
 		document.removeEventListener('drop', _onDrop)
 
-		onDropInside?.(node)
+		if (e.clientX < 0 || e.clientX > window.innerWidth || e.clientY < 0 || e.clientY > window.innerHeight) {
+			onDropOutside?.(node)
+		} else {
+			onDropInside?.(node)
+		}
 	}
 
 	const _onDrop = (e) => {


### PR DESCRIPTION
…ndow boundaries, #1

This PR fixes an issue when the target was dropped outisde the window boundaries: the wrong callback was triggered. We now trigger the  `onDropOutside` callback.

Closes #1 