### PR TITLE
feat: Add a callback when a drag is cancelled, #2

### DIFF
--- a/dev/src/App.svelte
+++ b/dev/src/App.svelte
@@ -8,6 +8,10 @@
 	const _onDropInside = (node) => {
 		alert(`You\'ve just dropped #${node.id} inside the area`)
 	}
+
+  const _onDragCancel = (node) => {
+    alert(`You\'ve just cancelled the drag of #${node.id}`)
+  }
 </script>
 
 <main>
@@ -19,6 +23,7 @@
 					areaSelector: '.area',
 					onDropOutside: _onDropOutside,
 					onDropInside: _onDropInside,
+					onDragCancel: _onDragCancel,
 				}}
 				class="target"
 			>

--- a/src/useDropOutside.js
+++ b/src/useDropOutside.js
@@ -10,7 +10,7 @@ let drag = null
 let dragWidth = 0
 let dragHeight = 0
 
-const useDropOutside = (node, { areaSelector, dragImage, onDropOutside, onDropInside }) => {
+const useDropOutside = (node, { areaSelector, dragImage, onDropOutside, onDropInside, onDragCancel }) => {
 	const area = document.querySelector(areaSelector)
 
 	const onMouseOver = (e) => {
@@ -44,14 +44,20 @@ const useDropOutside = (node, { areaSelector, dragImage, onDropOutside, onDropIn
 		document.addEventListener('mousemove', onMouseMove, false)
 		document.addEventListener('mouseup', onMouseUp, false)
 		document.addEventListener('touchmove', onMouseMove, false)
+		document.addEventListener('keydown', onMouseUp)
 		node.addEventListener('touchend', onMouseUp, false)
 		node.addEventListener('touchcancel', onMouseUp, false)
 	}
 
 	const onMouseUp = (e) => {
+		if (e.type.startsWith('key') && e.key !== 'Escape') {
+			return
+		}
+
 		document.removeEventListener('mousemove', onMouseMove)
 		document.removeEventListener('mouseup', onMouseUp)
 		document.removeEventListener('touchmove', onMouseMove)
+		document.removeEventListener('keydown', onMouseUp)
 		node.removeEventListener('touchend', onMouseUp)
 		node.removeEventListener('touchcancel', onMouseUp)
 
@@ -60,7 +66,9 @@ const useDropOutside = (node, { areaSelector, dragImage, onDropOutside, onDropIn
 		drag.remove()
 
 		setTimeout(() => {
-			if (doOverlap) {
+			if (e.type.startsWith('key')) {
+				onDragCancel?.(node)
+			} else if (doOverlap) {
 				onDropInside?.(node)
 			} else {
 				onDropOutside?.(node)


### PR DESCRIPTION
This PR allows to register a callback (`onDragCancel`) to be notified when the drag is cancelled, by pressing the Escape key.

Closes #2 