### PR TITLE
feat: Add area to callbacks arguments, #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,6 @@ yarn add @untemps/svelte-use-drop-outside
 	const _onDropOutside = (node) => {
 		console.log(`You\'ve just dropped #${node.id} outside the area`)
 	}
-
-	const _onDropInside = (node) => {
-		console.log(`You\'ve just dropped #${node.id} inside the area`)
-	}
-	
-	const _onDragCancel = (node) => {
-	    console.log(`You\'ve just cancelled the drag of #${node.id}`)
-	}
 </script>
 
 <main>
@@ -55,8 +47,6 @@ yarn add @untemps/svelte-use-drop-outside
 				use:useDropOutside={{
 					areaSelector: '.area',
 					onDropOutside: _onDropOutside,
-					onDropInside: _onDropInside,
-					onDragCancel: _onDragCancel,
 				}}
 				class="target"
 			>
@@ -209,11 +199,24 @@ The `dragImage` prop may be:
 
 ### Callbacks
 
-All callbacks are triggered with the dragged element as first and unique argument:
+All callbacks are triggered with the following arguments:
+
+| Argument | Description                               |
+|----------|-------------------------------------------|
+| [0]      | Dragged element.                          |
+| [1]      | Element considered as the "inside" area. |
 
 ```javascript
-const _onDropOutside = (node) => {
-  console.log(`You\'ve just dropped #${node.id} outside the area`)
+const _onDropOutside = (node, area) => {
+  console.log(`You\'ve just dropped #${node.id} outside the #${area.id}`)
+}
+
+const _onDropInside = (node, area) => {
+  console.log(`You\'ve just dropped #${node.id} inside the #${area.id}`)
+}
+
+const _onDragCancel = (node, area) => {
+  console.log(`You\'ve just cancelled the drag of #${node.id} against #${area.id} boundaries`)
 }
 ```
 
@@ -231,8 +234,7 @@ You may use the action to implement a classic drag and drop container switch usi
 <script>
 	import { useDropOutside } from '@untemps/svelte-use-drop-outside'
 
-	const _onDropInside = (node) => {
-    const area = document.querySelector('#destination-area')
+	const _onDropInside = (node, area) => {
 		area.appendChild(node)
 	}
 </script>

--- a/README.md
+++ b/README.md
@@ -32,68 +32,68 @@ yarn add @untemps/svelte-use-drop-outside
 
 ```svelte
 <script>
-	import { useDropOutside } from '@untemps/svelte-use-drop-outside'
-
-	const _onDropOutside = (node) => {
-		console.log(`You\'ve just dropped #${node.id} outside the area`)
-	}
+    import { useDropOutside } from '@untemps/svelte-use-drop-outside'
+    
+    const _onDropOutside = (node) => {
+        console.log(`You\'ve just dropped #${node.id} outside the area`)
+    }
 </script>
 
 <main>
-	<div class="container">
-		<div class="area">
-			<div
-				id="target"
-				use:useDropOutside={{
-					areaSelector: '.area',
-					onDropOutside: _onDropOutside,
-				}}
-				class="target"
-			>
-				Drag me outside the white area
-			</div>
-		</div>
-	</div>
+    <div class="container">
+        <div class="area">
+            <div
+                id="target"
+                use:useDropOutside={{
+                    areaSelector: '.area',
+                    onDropOutside: _onDropOutside,
+                }}
+                class="target"
+            >
+                Drag me outside the white area
+            </div>
+        </div>
+    </div>
 </main>
 
 <style>
-	main {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		height: 100%;
-		padding: 1rem;
-		background-color: #617899;
-	}
-
-	.container {
-		max-width: 640px;
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		row-gap: 3rem;
-	}
-
-	.area {
-		width: 300px;
-		height: 300px;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		background-color: white;
-		box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.5);
-	}
-
-	.target {
-		width: 10rem;
-		background-color: black;
-		color: white;
-		text-align: center;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		padding: 1rem;
-	}
+    main {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 100%;
+        padding: 1rem;
+        background-color: #617899;
+    }
+    
+    .container {
+        max-width: 640px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        row-gap: 3rem;
+    }
+    
+    .area {
+        width: 300px;
+        height: 300px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background-color: white;
+        box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.5);
+    }
+    
+    .target {
+        width: 10rem;
+        background-color: black;
+        color: white;
+        text-align: center;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 1rem;
+    }
 </style>
 ```
 
@@ -127,20 +127,20 @@ The `dragImage` prop may be:
 
 ```svelte
 <main>
-	<div class="container">
-		<div class="area">
-			<div
-				id="target"
-				use:useDropOutside={{
-					areaSelector: '.area',
-					dragImage: document.querySelector('#drag-image'),
-				}}
-				class="target"
-			>
-				Drag me outside the white area
-			</div>
-		</div>
-	</div>
+    <div class="container">
+        <div class="area">
+            <div
+                id="target"
+                use:useDropOutside={{
+                    areaSelector: '.area',
+                    dragImage: document.querySelector('#drag-image'),
+                }}
+                class="target"
+            >
+                Drag me outside the white area
+            </div>
+        </div>
+    </div>
 </main>
 <img id="drag-image" src="./assets/drag-image.png" alt="Dragging image" width="48" height="48"/>
 ```
@@ -155,24 +155,24 @@ The `dragImage` prop may be:
 
 ```svelte
 <main>
-	<div class="container">
-		<div class="area">
-			<div
-				id="target"
-				use:useDropOutside={{
-					areaSelector: '.area',
-					dragImage: {
-					    src: './assets/drag-image.png',
-					    width: 48,
-					    height: 48
-					},
-				}}
-				class="target"
-			>
-				Drag me outside the white area
-			</div>
-		</div>
-	</div>
+    <div class="container">
+        <div class="area">
+            <div
+                id="target"
+                use:useDropOutside={{
+                    areaSelector: '.area',
+                    dragImage: {
+                        src: './assets/drag-image.png',
+                        width: 48,
+                        height: 48
+                    },
+                }}
+                class="target"
+            >
+                Drag me outside the white area
+            </div>
+        </div>
+    </div>
 </main>
 ```
 
@@ -180,20 +180,20 @@ The `dragImage` prop may be:
 
 ```svelte
 <main>
-	<div class="container">
-		<div class="area">
-			<div
-				id="target"
-				use:useDropOutside={{
-					areaSelector: '.area',
-					dragImage: './assets/drag-image.png',
-				}}
-				class="target"
-			>
-				Drag me outside the white area
-			</div>
-		</div>
-	</div>
+    <div class="container">
+        <div class="area">
+            <div
+                id="target"
+                use:useDropOutside={{
+                    areaSelector: '.area',
+                    dragImage: './assets/drag-image.png',
+                }}
+                class="target"
+            >
+                Drag me outside the white area
+            </div>
+        </div>
+    </div>
 </main>
 ```
 
@@ -232,69 +232,69 @@ You may use the action to implement a classic drag and drop container switch usi
 
 ```svelte
 <script>
-	import { useDropOutside } from '@untemps/svelte-use-drop-outside'
-
-	const _onDropInside = (node, area) => {
-		area.appendChild(node)
-	}
+    import { useDropOutside } from '@untemps/svelte-use-drop-outside'
+    
+    const _onDropInside = (node, area) => {
+        area.appendChild(node)
+    }
 </script>
 
 <main>
-	<div class="container">
-    <div id="origin-area" class="area">
-      <div
-        id="target"
-        use:useDropOutside={{
-					areaSelector: '#destination-area',
-					onDropInside: _onDropInside,
-				}}
-        class="target"
-      >
-        Drag me into the second area
-      </div>
+    <div class="container">
+        <div id="origin-area" class="area">
+          <div
+            id="target"
+            use:useDropOutside={{
+                areaSelector: '#destination-area',
+                onDropInside: _onDropInside,
+            }}
+            class="target"
+          >
+            Drag me into the second area
+          </div>
+        </div>
+        <div id="destination-area" class="area"></div>
     </div>
-    <div id="destination-area" class="area"></div>
-	</div>
 </main>
 
 <style>
-	main {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		height: 100%;
-		padding: 1rem;
-		background-color: #617899;
-	}
-
-	.container {
-		max-width: 640px;
-		display: flex;
-		flex-direction: row;
-		align-items: center;
-		gap: 3rem;
-	}
-
-	.area {
-		width: 300px;
-		height: 300px;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		background-color: white;
-		box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.5);
-	}
-
-	.target {
-		width: 10rem;
-		background-color: black;
-		color: white;
-		text-align: center;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		padding: 1rem;
-	}
+    main {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 100%;
+        padding: 1rem;
+        background-color: #617899;
+    }
+    
+    .container {
+        max-width: 640px;
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: 3rem;
+    }
+    
+    .area {
+        width: 300px;
+        height: 300px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background-color: white;
+        box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.5);
+    }
+    
+    .target {
+        width: 10rem;
+        background-color: black;
+        color: white;
+        text-align: center;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 1rem;
+    }
 </style>
 
 ```

--- a/dev/src/App.svelte
+++ b/dev/src/App.svelte
@@ -1,12 +1,12 @@
 <script>
 	import { useDropOutside } from '../../src'
 
-	const _onDropOutside = (node) => {
-		alert(`You\'ve just dropped #${node.id} outside the area`)
+	const _onDropOutside = (node, area) => {
+		alert(`You\'ve just dropped #${node.id} outside #${area.id}`)
 	}
 
-	const _onDropInside = (node) => {
-		alert(`You\'ve just dropped #${node.id} inside the area`)
+	const _onDropInside = (node, area) => {
+		alert(`You\'ve just dropped #${node.id} inside #${area.id}`)
 	}
 
   const _onDragCancel = (node) => {
@@ -16,7 +16,7 @@
 
 <main>
 	<div class="container">
-		<div class="area">
+		<div id="area" class="area">
 			<div
 				id="target"
 				use:useDropOutside={{
@@ -32,9 +32,6 @@
 		</div>
 	</div>
 </main>
-<template id="drag-image">
-  <img src="https://cdn-icons-png.flaticon.com/512/636/636045.png" alt="dragging" width="48" height="48"/>
-</template>
 
 <style>
 	main {

--- a/src/useDropOutside.js
+++ b/src/useDropOutside.js
@@ -67,11 +67,11 @@ const useDropOutside = (node, { areaSelector, dragImage, onDropOutside, onDropIn
 
 		setTimeout(() => {
 			if (e.type.startsWith('key')) {
-				onDragCancel?.(node)
+				onDragCancel?.(node, area)
 			} else if (doOverlap) {
-				onDropInside?.(node)
+				onDropInside?.(node, area)
 			} else {
-				onDropOutside?.(node)
+				onDropOutside?.(node, area)
 			}
 		}, 10)
 	}


### PR DESCRIPTION
This PR adds the reference of the area in all callbacks calls.
This allows to use the area directly without have to query it from the DOM, which is especially useful when it comes to append the dragged element to that area (see docs).

Closes #8 