### PR TITLE
feat: Animate drag cancellation and inside drop back, #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,14 +100,16 @@ yarn add @untemps/svelte-use-drop-outside
 
 ## API
 
-| Props                 | Type                        | Default            | Description                                                             |
-|-----------------------|-----------------------------|--------------------|-------------------------------------------------------------------------|
-| `areaSelector`        | string                      | null               | Selector of the element considered as the "inside" area.                |
-| `dragImage`           | element or object or string | null               | The image used when the element is dragging.                            |
-| `dragClassName`       | string                      | null               | A class name that will be assigned to the dragged element.           |
-| `onDropOutside`       | function                    | null               | Callback triggered when the dragged element is dropped outside the area. |
-| `onDropInside`        | function                    | null               | Callback triggered when the dragged element is dropped inside the area  |
-| `onDragCancel`        | function                    | null               | Callback triggered when the drag is cancelled (Esc key)                 |
+| Props            | Type                        | Default                                  | Description                                                                            |
+|------------------|-----------------------------|------------------------------------------|----------------------------------------------------------------------------------------|
+| `areaSelector`   | string                      | null                                     | Selector of the element considered as the "inside" area.                               |
+| `dragImage`      | element or object or string | null                                     | The image used when the element is dragging.                                           |
+| `dragClassName`  | string                      | null                                     | A class name that will be assigned to the dragged element.                             |
+| `animate`        | boolean                     | false                                    | A flag to enable animation back.                                                       |
+| `animateOptions` | object                      | { duration: .2, timingFunction: 'ease' } | Optional options for the animation back (see [Animation Options](#animation-options)). |
+| `onDropOutside`  | function                    | null                                     | Callback triggered when the dragged element is dropped outside the area.               |
+| `onDropInside`   | function                    | null                                     | Callback triggered when the dragged element is dropped inside the area                 |
+| `onDragCancel`   | function                    | null                                     | Callback triggered when the drag is cancelled (Esc key)                                |
 
 ### Area Selector
 
@@ -237,13 +239,28 @@ The class declaration will be parsed and set to the `style` attribute of the dra
 </style>
 ```
 
+### Animation
+
+By default, when the dragged element is dropped inside the area or if the drag is cancelled, the dragged element is plainly removed.
+
+When setting the `animate` to `true`, when those events happen, the dragged element is smoothly moved back to its original position.
+
+#### Animation Options
+
+The animation can be configured through the `animateOptions` prop:
+
+| Argument       | Type   | Default | Description                                                                                                                                               |
+|----------------|--------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| duration       | number | .2      | Duration of the animation (in seconds).                                                                                                                   |
+| timingFunction | string | 'ease'  | Function that defines the animation effect (see [animation-timing-function](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-timing-function)). |
+
 ### Callbacks
 
 All callbacks are triggered with the following arguments:
 
-| Argument | Description                               |
-|----------|-------------------------------------------|
-| [0]      | Dragged element.                          |
+| Argument | Description                              |
+|----------|------------------------------------------|
+| [0]      | Dragged element.                         |
 | [1]      | Element considered as the "inside" area. |
 
 ```javascript

--- a/dev/src/App.svelte
+++ b/dev/src/App.svelte
@@ -44,6 +44,10 @@
         {#each colors as color, index}
           <li use:useDropOutside={{
             areaSelector: '.area',
+            animate: true,
+            animateOptions: {
+              timingFunction: 'cubic-bezier(0.175, 0.885, 0.32, 1.275)'
+            },
             onDropOutside: _onDropOutside,
             onDropInside: _onDropInside,
             onDragCancel: _onDragCancel,

--- a/src/DragAndDrop.js
+++ b/src/DragAndDrop.js
@@ -92,6 +92,21 @@ class DragAndDrop {
 		this.#observer = null
 	}
 
+	#animateBack(callback) {
+		this.#drag.style.setProperty('--origin-x', this.#target.getBoundingClientRect().left + 'px')
+		this.#drag.style.setProperty('--origin-y', this.#target.getBoundingClientRect().top + 'px')
+		this.#drag.style.animation = 'move .2s ease'
+		this.#drag.addEventListener(
+			'animationend',
+			() => {
+				this.#drag.style.animation = 'none'
+				this.#drag.remove()
+				callback?.(this.#target, this.#area)
+			},
+			false
+		)
+	}
+
 	#onMouseOver(e) {
 		e.target.style.cursor = 'grab'
 	}
@@ -151,14 +166,13 @@ class DragAndDrop {
 
 		const doOverlap = doElementsOverlap(this.#area, this.#drag)
 
-		this.#drag.remove()
-
 		setTimeout(() => {
 			if (e.type.startsWith('key')) {
-				this.#onDragCancel?.(this.#target, this.#area)
+				this.#animateBack(this.#onDragCancel)
 			} else if (doOverlap) {
-				this.#onDropInside?.(this.#target, this.#area)
+				this.#animateBack(this.#onDropInside)
 			} else {
+				this.#drag.remove()
 				this.#onDropOutside?.(this.#target, this.#area)
 			}
 		}, 10)

--- a/src/__tests__/useDropOutside.test.js
+++ b/src/__tests__/useDropOutside.test.js
@@ -6,7 +6,6 @@ import { fireEvent, screen } from '@testing-library/dom'
 
 import { createElement } from '@untemps/utils/dom/createElement'
 import { getElement } from '@untemps/utils/dom/getElement'
-import { standby } from '@untemps/utils/async/standby'
 
 import DragAndDrop from '../DragAndDrop'
 import useDropOutside from '../useDropOutside'
@@ -115,13 +114,11 @@ describe('useDropOutside', () => {
 			const drag = getElement('#drag')
 			expect(drag).toBeInTheDocument()
 			fireEvent.mouseUp(document)
-			await standby()
-			fireEvent.animationEnd(screen.getByRole('presentation'))
 			expect(drag).not.toBeInTheDocument()
 		})
 
 		it('Triggers onDropInside callback', async () => {
-			useReturn = useDropOutside(target, options)
+			useReturn = useDropOutside(target, { ...options, animate: true })
 			fireEvent.touchStart(target, { targetTouches: [{ pageX: 10, pageY: 10 }] })
 			fireEvent.touchMove(document, { targetTouches: [{ pageX: 10, pageY: 10 }] })
 			fireEvent.touchMove(document, { targetTouches: [{ pageX: 10, pageY: 10 }] }) // Duplicate on purpose
@@ -135,7 +132,6 @@ describe('useDropOutside', () => {
 				bottom: targetSize,
 			})
 			fireEvent.mouseUp(document)
-			await standby()
 			fireEvent.animationEnd(screen.getByRole('presentation'))
 			expect(onDropInside).toHaveBeenCalled()
 		})
@@ -154,17 +150,15 @@ describe('useDropOutside', () => {
 				bottom: areaSize + 10 + targetSize,
 			})
 			fireEvent.mouseUp(document)
-			await standby()
 			expect(onDropOutside).toHaveBeenCalled()
 		})
 
 		it('Triggers onDragCancel callback', async () => {
-			useReturn = useDropOutside(target, options)
+			useReturn = useDropOutside(target, { ...options, animate: true })
 			fireEvent.mouseDown(target)
 			fireEvent.mouseMove(document)
 			fireEvent.keyDown(document, { key: 'A', code: 'A' })
 			fireEvent.keyDown(document, { key: 'Escape', code: 'Esc' })
-			await standby()
 			fireEvent.animationEnd(screen.getByRole('presentation'))
 			expect(onDragCancel).toHaveBeenCalled()
 		})

--- a/src/__tests__/useDropOutside.test.js
+++ b/src/__tests__/useDropOutside.test.js
@@ -115,6 +115,8 @@ describe('useDropOutside', () => {
 			const drag = getElement('#drag')
 			expect(drag).toBeInTheDocument()
 			fireEvent.mouseUp(document)
+			await standby()
+			fireEvent.animationEnd(screen.getByRole('presentation'))
 			expect(drag).not.toBeInTheDocument()
 		})
 
@@ -134,6 +136,7 @@ describe('useDropOutside', () => {
 			})
 			fireEvent.mouseUp(document)
 			await standby()
+			fireEvent.animationEnd(screen.getByRole('presentation'))
 			expect(onDropInside).toHaveBeenCalled()
 		})
 
@@ -162,6 +165,7 @@ describe('useDropOutside', () => {
 			fireEvent.keyDown(document, { key: 'A', code: 'A' })
 			fireEvent.keyDown(document, { key: 'Escape', code: 'Esc' })
 			await standby()
+			fireEvent.animationEnd(screen.getByRole('presentation'))
 			expect(onDragCancel).toHaveBeenCalled()
 		})
 

--- a/src/useDropOutside.css
+++ b/src/useDropOutside.css
@@ -3,4 +3,14 @@
     z-index: 999;
     user-select: none;
     opacity: .7;
+
+    --origin-x: 0px;
+    --origin-y: 0px;
+}
+
+@keyframes move {
+    100% {
+        left: var(--origin-x);
+        top: var(--origin-y);
+    }
 }

--- a/src/useDropOutside.js
+++ b/src/useDropOutside.js
@@ -2,13 +2,15 @@ import DragAndDrop from './DragAndDrop'
 
 const useDropOutside = (
 	node,
-	{ areaSelector, dragImage, dragClassName, onDropOutside, onDropInside, onDragCancel }
+	{ areaSelector, dragImage, dragClassName, animate, animateOptions, onDropOutside, onDropInside, onDragCancel }
 ) => {
 	const instance = new DragAndDrop(
 		node,
 		areaSelector,
 		dragImage,
 		dragClassName,
+		animate,
+		animateOptions,
 		onDropOutside,
 		onDropInside,
 		onDragCancel


### PR DESCRIPTION
This PR adds two new props : `animate` and `animateOptions` to enable and configure animation when the dragged element is dropped inside the area or if the drag is cancelled.

Closes #10 